### PR TITLE
bug: buildproto ~ begin review of node options for node 17.5

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -9,7 +9,7 @@ last 2 versions
 Firefox ESR
 
 [node]
-node >= 14
+node >= 16.14
 
 # es6 modules: set type="module" on the script tag in your html
 [es6]

--- a/.npmrc
+++ b/.npmrc
@@ -3,6 +3,7 @@
 ; @see https://pnpm.io/workspaces
 ; @see https://yarnpkg.com/features/pnp
 ; @see https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-npm-registry
+; @see https://pnpm.io/blog/2020/10/17/node-modules-configuration-options-with-pnpm
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; opinions
@@ -14,6 +15,9 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; the following settings impact virtualization
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; we dont use node-linker=pnp as it breaks flowtyped
+; thus using the second most strict node_modules architecture
+; ^ no hoisting, with node-linker=isolated
 ; hoisting settings ;;;;;;;;;;;;;;;;;;;;
 ; true === makes unlisted deps accessible to all packages inside node_modules
 hoist = false
@@ -21,6 +25,10 @@ hoist = false
 ; hoists dependencies to a hidden modules directory inside the virtual store
 ; makes unlisted/phantom deps available to pkgs in node modules only
 hoist-pattern = []
+; hoist-pattern[]=*
+; hoist-pattern[]=*eslint*
+; hoist-pattern[]=*babel*
+; hoist-pattern[]=*nodeproto*
 ; hoists dependencies to the root modules directory
 ; makes unlisted/phantom deps available to application code + modules
 ; useful when dealing with some flawed pluggable tools that don't resolve dependencies properly.
@@ -40,7 +48,7 @@ store-dir = /var/.nodeproto/.pnpm-store
 modules-dir = node_modules
 ; what linker should be used for installing node packages
 ; hoisted = npm/yarn classic
-; pnpm = yarn berry
+; pnp = yarn berry; make sure to delete root/pnp.js if not using this
 ; isolated = symlinked
 node-linker = isolated
 ; must be false when node-linker=pnp

--- a/README.md
+++ b/README.md
@@ -6,25 +6,29 @@
   - docker in prod (todo)
 
 - hard requirements for develop branch
-  - haproxy (needs virtualization)
-  - node + corepack >= 17.5
-  - pnpm >= 6.30.1
-  - react + react-dom @rc (or @next)
-  - koa => 2
-  - flowtype >= 0.171.0
-  - Signoz APM (todo)
-  - Consul (todo)
-  - Arangodb (todo)
-  - ClickHouse (todo)
-  - all packages export reusable type definitions as `@nodeproto/packagename/src/libdefs`
-
-- cultural boundaries
-  - bleeding edge always
-  - best in class > most popular
-  - terse clarity > verbose expressiveness
-  - monorepo microservices > multirepo microservices
-  - read the code > read the comments
-  - tests are first class citizens
+  - dependency requirements
+    - haproxy (needs virtualization)
+    - node + corepack >= 17.5
+    - pnpm >= 6.30.1
+    - react + react-dom @rc (or @next)
+    - koa => 2
+    - flowtype >= 0.171.0
+    - Signoz APM (todo)
+    - Consul (todo)
+    - Arangodb (todo)
+    - ClickHouse (todo)
+  - process requirements
+    - package.json.config is controlled  by root/package.json and synced to child packages via tools/jsync
+    - all packages export reusable type definitions as `@nodeproto/packagename/src/libdefs`
+  - cultural boundaries
+    - best in class > most popular
+    - bleeding edge always
+    - monorepo microservices > multirepo microservices
+    - read the code > read the comments
+    - specification > kitchen sinks
+    - terse clarity > verbose expressiveness
+    - tests are first class citizens
+    - trunk > branch
 
 ## TLDR
 
@@ -65,7 +69,6 @@
 
   # dependencies
   pnpm install
-  pnpm proto repo:cp:configproto
   pnpm proto repo:flowtyped:install # also useful for updating typedefs across dependent packages
 
   # introspection
@@ -76,9 +79,6 @@
 ### monorepo utility logic
 
 ```sh
-  # copy static files from configproto into each package
-  pnpm proto repo:cp:configproto
-
   # synchronize root/package.json into each package/package.json
   pnpm proto repo:jsync
 
@@ -166,15 +166,8 @@
 
 
   #########
-  # should only be run by your build script
-  $ pnpm repo:cp:cjs # copy configproto/package.json into package/dist/package.json
-  # ^ for setting the dist to commonjs
-  $ pnpm repo:cp:configproto # copy configproto/[flow,cjs,browserslist] into package
-
   #########
   # useful if run with pnpm proto, e.g. pnpm proto repo:nuke
-  $ pnpm repo:cp:browserslist # copy configproto/browserslistrc into package
-  $ pnpm repo:cp:flow # copy configproto/.flowconfig into package
   $ pnpm repo:flowtyped:install # install flow-type defs
   $ pnpm repo:jsync # sync child package.json with root package.json
   $ pnpm repo:nuke # rm /dist & /node_modules directories

--- a/TODO/tools/inception/bin/ultra.cjs
+++ b/TODO/tools/inception/bin/ultra.cjs
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 
 
 // @see https://github.com/folke/ultra-runner/blob/master/__tests__/runner.ts

--- a/TODO/tools/inception/configs/chokidar.config.mjs
+++ b/TODO/tools/inception/configs/chokidar.config.mjs
@@ -20,4 +20,4 @@ export const chokidarConfigDefault = {
     useFsEvents: false,
     usePolling: true,
     usePolling: false,
-  }
+  };

--- a/TODO/tools/inception/index.mjs
+++ b/TODO/tools/inception/index.mjs
@@ -76,7 +76,7 @@ const commandCenter = {
 
 const babysit = async () => {
   nodeTop(3000);
-}
+};
 
 // TODO
 export const createServiceConfig = async ({
@@ -99,7 +99,7 @@ export const createServiceConfig = async ({
   const pkgJsonString = shelljs.ls(workDirAbs + '/package.json')?.[0];
 
   if (typeof pkgJsonString !== 'string') {
-    ErrorCreateServiceConfig('unable to find pkgjson', {key, workDir, workDirAbs, pkgJsonString }, 'filepath');
+    ErrorCreateServiceConfig('unable to find pkgjson', { key, workDir, workDirAbs, pkgJsonString }, 'filepath');
 
     pkg.json = {};
   }
@@ -111,13 +111,12 @@ export const createServiceConfig = async ({
 
       success(`successfully created config for ${key} installable as ${pkg.name}`);
     } catch (e) {
-      ErrorCreateServiceConfig(e.message, { key, workDir, workDirAbs, pkg }, 'unknown')
+      ErrorCreateServiceConfig(e.message, { key, workDir, workDirAbs, pkg }, 'unknown');
     }
   }
 
   return pkg;
 };
-
 
 
 /**
@@ -161,7 +160,7 @@ const linkPkgsTailCall = async (pkgKey, downstreamDeps) => {
       downstreamDep.workDirAbs + '/node_modules/' + pkg.name // to
     ).catch(e => ErrorLinkPkgs(
       'error link downstream dependencies',
-      {e, name: pkg.name, pkg,},
+      { e, name: pkg.name, pkg, },
       'symlinkDir'
     ));
 
@@ -175,7 +174,7 @@ const linkPkgsTailCall = async (pkgKey, downstreamDeps) => {
   }
 
   return packagesLinked;
-}
+};
 
 /**
  * links an arbitrary number of downstream pkgs to their upstream (grnad)parents
@@ -209,7 +208,7 @@ const linkPkgs = async (pkgKey, downstreamDeps) => {
  * @return {*}
  */
 const buildPkgsTailCall = async (pkg) => {
-  if (!pkg || !pkg.key) ErrorBuildPkgs('unable to build pkgs: invalid pkg', { pkg }, 'buildPkgsTailCall')
+  if (!pkg || !pkg.key) ErrorBuildPkgs('unable to build pkgs: invalid pkg', { pkg }, 'buildPkgsTailCall');
 
   const {
     key: pkgKey,
@@ -232,13 +231,12 @@ const buildPkgsTailCall = async (pkg) => {
 
           log('pkg built: ', pkgKey, json.name);
         } catch (e) {
-          ErrorBuildPkgs(`error in ${pkgKey} build script: ${scriptBuild}`, e, 'build error')
-          commandCenter.state.built.delete(pkgKey)
-          commandCenter.state.building.delete(pkgKey)
+          ErrorBuildPkgs(`error in ${pkgKey} build script: ${scriptBuild}`, e, 'build error');
+          commandCenter.state.built.delete(pkgKey);
+          commandCenter.state.building.delete(pkgKey);
           pkg.inception.built = false;
 
           return false;
-
         }
 
         commandCenter.state.built.add(pkgKey);
@@ -247,13 +245,13 @@ const buildPkgsTailCall = async (pkg) => {
       `${commandCenter.state.built.has(pkgKey) ? 'rebuilding' : 'building'} pkg`
     ); // end cdBack
   } catch (e) {
-    ErrorBuildPkgs('unknown error building single pkg', {e, pkg, pkgKey}, 'build pkgs tailcall');
+    ErrorBuildPkgs('unknown error building single pkg', { e, pkg, pkgKey }, 'build pkgs tailcall');
 
     return false;
   }
 
   return true;
-}
+};
 
 /**
  * builds a single, or all pkgs
@@ -269,13 +267,12 @@ const buildPkgs = async (pkg) => {
 
   return Array.from(buildablePkgs.values()).forEach(pkg => {
     try {
-      return buildPkgs(commandCenter.pkgs.get(pkg))
-
+      return buildPkgs(commandCenter.pkgs.get(pkg));
     } catch (e) {
-      ErrorBuildPkgs('unable to build all pkgs', {e, pkg}, 'pkg build error')
+      ErrorBuildPkgs('unable to build all pkgs', { e, pkg }, 'pkg build error');
     }
-  })
-}
+  });
+};
 
 /**
  * Creates a pkg management plan for each pkg management configuration
@@ -294,10 +291,7 @@ const createPkgManagementPlan = async () => {
     const willStart = !!isStartable(pkg);
 
     log(
-      'pkg management plan: ', pkg.name,
-      `\n build: ${prevB}`,
-      `\n link: ${pkgsToLink.length}`,
-      `\n start: ${willStart}`
+      'pkg management plan: ', pkg.name, `\n build: ${prevB}`, `\n link: ${pkgsToLink.length}`, `\n start: ${willStart}`
 
     );
 
@@ -319,21 +313,18 @@ const createPkgManagementPlan = async () => {
 
       ++totalPkgs;
     } catch (e) {
-      ErrorCreatePkgManagementPlan('setting up unique packages', {e, pkgKey, pkg }, 'create');
+      ErrorCreatePkgManagementPlan('setting up unique packages', { e, pkgKey, pkg }, 'create');
     }
   };
 
-  if (!totalPkgs) ErrorCreatePkgManagementPlan('services are neither buildable, pushable, or startable', { totalPkgs }, 'service definitions')
+  if (!totalPkgs) ErrorCreatePkgManagementPlan('services are neither buildable, pushable, or startable', { totalPkgs }, 'service definitions');
 
   success(
-    'unique services saved:', totalPkgs,
-    `\n packages to build: ${buildablePkgs.size}`,
-    `\n packages to link: ${linkablePkgs.size}`,
-    `\n packages to start: ${startablePkgs.size}`
+    'unique services saved:', totalPkgs, `\n packages to build: ${buildablePkgs.size}`, `\n packages to link: ${linkablePkgs.size}`, `\n packages to start: ${startablePkgs.size}`
   );
 
   return true;
-}
+};
 
 /**
  * Ingests service definitions and creates pkg managent configurations
@@ -344,17 +335,17 @@ const compileServiceDefinitions = async () => {
   info('\n compiling service definitions');
 
   for (const [key, def] of Object.entries(services)) {
-    const pkg = await createServiceConfig({ key, ...def })
+    const pkg = await createServiceConfig({ key, ...def });
 
     if (!pkg) error('\n could not create pkg', key, def);
-    else if (commandCenter.pkgs.has(key)) ErrorCompileServiceDefinitions('duplicate service', {key, def}, 'unique service')
+    else if (commandCenter.pkgs.has(key)) ErrorCompileServiceDefinitions('duplicate service', { key, def }, 'unique service');
     else commandCenter.pkgs.set(key, pkg);
   }
 
   log('\n commandCenter', commandCenter);
 
   return true;
-}
+};
 
 /** @type {*} array of available scripts suitable for logging to stdout */
 const availScripts = [
@@ -394,15 +385,15 @@ else log = noop, info = infoIt;
 const pkgManagementPlanLifecycle = async () => Promise.resolve()
   .then(() => compileServiceDefinitions())
   .then(() => createPkgManagementPlan())
-  .catch(e => ErrorInception('pkg management plan lifecycle error', {e}, 'lifecycle'));
+  .catch(e => ErrorInception('pkg management plan lifecycle error', { e }, 'lifecycle'));
 
 const buildPkgsLifecycle = async () => Promise.resolve()
   .then(() => buildPkgs())
-  .catch(e => ErrorInception('build pkgs lifecycle error', {e}, 'lifecyle'));
+  .catch(e => ErrorInception('build pkgs lifecycle error', { e }, 'lifecyle'));
 
 const linkPkgsLifecycle = async () => Promise.resolve()
   .then(() => linkPkgs())
-  .catch(e => ErrorInception('link pkgs lifecycle', {e}, 'lifecycle'));
+  .catch(e => ErrorInception('link pkgs lifecycle', { e }, 'lifecycle'));
 
 /** inception invocation */
 (async () => {

--- a/TODO/tools/inception/serviceDefinitions.mjs
+++ b/TODO/tools/inception/serviceDefinitions.mjs
@@ -6,7 +6,7 @@ export const globalOptions = {
   chokidarConfig: {},
   runner: 'npm run', // enum(true)
   watchGlob: /src\/.*\.(c|m)?js|css|tsx$/, // javascript and css files
-}
+};
 
 // @see https://github.com/nodejs/node-eps/blob/master/002-es-modules.md#4-compatibility
 // symlinks to ~/.node_modules will always work, with a performance hit but hey
@@ -22,25 +22,25 @@ const defaultService = {
   upstreamDeps: [], // pkgJson.name, list of pkgs this pkg depends on
   watch: true,
   workDir: '', // directory with pkg.json, must be unique
-}
+};
 
 export const dep1 = {
   ...defaultService,
   workDir: './fixtures/fakedeps/dep1',
   upstreamDeps: ['dep2'],
   scriptBuild: 'build:dep1',
-}
+};
 
 export const dep2 = {
   ...defaultService,
   workDir: './fixtures/fakedeps/dep2',
   scriptBuild: 'build',
-}
+};
 
 export const client = {
   ...defaultService,
   workDir: '../../apps/client',
   scriptStart: 'start:dev',
   upstreamDeps: ['dep1'],
-}
+};
 

--- a/TODO/tools/inception/utils/utils.mjs
+++ b/TODO/tools/inception/utils/utils.mjs
@@ -49,7 +49,7 @@ export const cdBack = async (toDir, fn, because = 'Running script') => {
   }
 
   return true;
-}
+};
 
 // not used at the moment
 // @see https://stackoverflow.com/questions/37521893/determine-if-a-path-is-subdirectory-of-another-in-node-js
@@ -57,7 +57,7 @@ const pkgOf = (path1, path2) => {
   if (path1 === path2) return true;
   const [parent, child] = path1.length > path2.length
     ? [path2, path1]
-    : [path1, path2]
+    : [path1, path2];
 
   console.log('\n parent:child', parent, child);
   const relative = path.relative(parent, child);
@@ -65,11 +65,11 @@ const pkgOf = (path1, path2) => {
   const response = relative && !relative.startsWith('..') && !path.isAbsolute(relative);
   console.log('\n relative', response, relative, !relative.startsWith('..'), !path.isAbsolute(relative) );
 
-  return response
-}
+  return response;
+};
 
 // not used anymore
 // TODO: maybe not needed anymore
 const getPkgVersion = pkgName => (
   Array.from(uniquePkgs.values()).filter(pkg => pkg.name === pkgName).pop().inception.version
-)
+);

--- a/TODO/tools/inception/utils/watch.mjs
+++ b/TODO/tools/inception/utils/watch.mjs
@@ -15,7 +15,7 @@ const watchablePkgs = new Set();
 // TODO: we need to understand if they are using an internal watch
 // + likely they should set pkg.watch = false
 const rebuildCallback = async usePath => {
-  console.log('\n\n rebuild called')
+  console.log('\n\n rebuild called');
   const filename = path.basename(usePath);
   const dirname = path.resolve(cwd, path.dirname(usePath));
 
@@ -37,11 +37,11 @@ const rebuildCallback = async usePath => {
   // }
 
   // warn('could not find pkg related to changed file: ', filename, dirname, pkgDirWatchMap)
-}
+};
 
 const errorCallback = async usePath => {
-  ErrorWatchPkgs('unable to watch path', { usePath, pathsToWatch }, 'chokidar error')
-}
+  ErrorWatchPkgs('unable to watch path', { usePath, pathsToWatch }, 'chokidar error');
+};
 
 const watchPkgs = async () => {
   info('starting watcher');
@@ -53,8 +53,8 @@ const watchPkgs = async () => {
       'unknown pkg found',
       { pkgKey, pkgs: commandCenter.pkgs.keys() },
       'watch error'
-    )
-    else pathsToWatch.set(pkgKey, pkg.workDirAbs)
+    );
+    else pathsToWatch.set(pkgKey, pkg.workDirAbs);
   }
 
   log('watching directories: ', pathsToWatch);
@@ -71,4 +71,4 @@ const watchPkgs = async () => {
   watcher.on('error', errorCallback);
 
   return true;
-}
+};

--- a/doc/node_options.md
+++ b/doc/node_options.md
@@ -1,0 +1,114 @@
+# @nodeproto: node options
+
+- [latest node_options spec](https://nodejs.org/api/cli.html#node_optionsoptions)
+- we rely heavily on root/package.json.config.node_options
+- packages/jsync is used to sync root/node_options to all child packages/node_options
+
+```sh
+# reporting & diagnostics
+--diagnostic-dir=\"/var/.nodeproto/node/diagnostics\"
+--redirect-warnings=warnings
+--report-compact
+--report-dir=\"/var/.nodeproto/node/reports\"
+--report-filename=node-report
+--report-on-fatalerror
+--report-on-signal
+--report-signal=SIGUSR2
+--report-uncaught-exception
+
+# enable/report on warnings
+--pending-deprecation
+--trace-deprecation
+--trace-exit
+--trace-sigint # specifically for SIGINT
+--trace-warnings # process warnings + deprecations
+--unhandled-rejections=strict
+
+# enable node features
+--enable-source-maps
+--experimental-abortcontroller
+--experimental-fetch
+--experimental-import-meta-resolve
+--experimental-json-modules
+--experimental-loader=\"./node_modules/@nodeproto/configproto/src/node/loaders/flow.mjs\"
+--experimental-modules
+--experimental-specifier-resolution=node
+--experimental-top-level-await
+--tls-max-v1.3
+--tls-min-v1.3
+--use-largepages=on # nodejs static code to be moved onto 2MiB pages isntead of 4 KiB
+
+# think these two accumulate to our import error with copy-webpack-plugin
+--preserve-symlinks-main # main module follows the symlink strategy as other modules
+--preserve-symlinks # use symlink path for modules (not on disk path); useful for peer deps
+
+```
+
+- node options requiring experimentation
+```sh
+# dont use: @see https://github.com/lukeed/uvu/issues/192
+--v8-pool-size=0 # v8 will chose an appropriate pool size based on # of online processors
+--heapsnapshot-near-heap-limit
+--max-old-space-size
+--heapsnapshot-signal= # potentially should be used in prod to investigate uncaught exceptions
+--policy-integrity=sri # @see https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity
+--secure-heap-min
+--secure-heap
+--use-bundled-ca
+--use-openssl-ca
+--zero-fill-buffers
+```
+
+- unused node options
+```sh
+--redirect-warnings=warnings
+--conditions, -C
+--disable-proto
+--dns-result-order
+--enable-fips
+--experimental-policy
+--experimental-vm-modules
+--experimental-wasi-unstable-preview1
+--experimental-wasm-modules
+--force-context-aware
+--force-fips
+--frozen-intrinsics
+--http-parser
+--icu-data-dir
+--input-type
+--insecure-http-parser
+--inspect-brk
+--inspect-port, --debug-port
+--inspect-publish-uid
+--inspect
+--max-http-header-size
+--napi-modules
+--no-addons
+--no-deprecation
+--no-experimental-repl-await
+--no-extra-info-on-fatal-exception
+--no-force-async-hooks-checks
+--no-global-search-paths
+--no-warnings
+--node-memory-debug
+--openssl-config
+--openssl-legacy-provider
+--prof-process
+--require, -r
+--throw-deprecation
+--title # sets process title
+--tls-cipher-list
+--tls-keylog
+--tls-max-v1.2
+--tls-min-v1.0
+--tls-min-v1.1
+--tls-min-v1.2
+--trace-atomics-wait
+--trace-event-categories
+--trace-event-file-pattern
+--trace-events-enabled
+--trace-uncaught # effects GC negatively
+--trace-sync-io
+--trace-tls
+--track-heap-objects
+```

--- a/doc/random.md
+++ b/doc/random.md
@@ -1,0 +1,13 @@
+```sh
+# displays the config used to transpile some file when running a pkg json script
+BABEL_SHOW_CONFIG_FOR=absolute/path/to/file somePkgJsonScriptName
+
+# a pkg json script when I was support cjs, but node 16 LTS should be the target transpiled so this is no longer relevant
+"repo:cp:cjs": "rm -f ./dist/package.json && mkdir -p dist && cp ./node_modules/@nodeproto/configproto/src/node/cjs.json ./dist/package.json",
+
+# pkg json script to convert dist/*.js files to dist/*cjs files
+"js:to:cjs": "for f in ./dist/**/*.js; do mv -- \"$f\" \"${f%.js}.cjs\"; done",
+
+# node doenst like the {} syntax i guess
+"repo:cp:configproto": "cp ./node_modules/@nodeproto/configproto/{.browserslistrc,.flowconfig,.prettier*} .",
+```

--- a/package.json
+++ b/package.json
@@ -15,9 +15,7 @@
   "repository": "git://github.com/noahehall/nodeproto.git",
   "type": "module",
   "version": "0.0.0",
-  "engines": {
-    "node": "^14.17.0 || ^16.11.0 || >=17.5.0"
-  },
+  "engines": { "node": "16.14.0 || 17.5.0" },
   "keywords": [
     "@nirv",
     "@nodeproto",
@@ -61,11 +59,8 @@
     "README.md"
   ],
   "config": {
-    "DIRS_TO_TRANSPILE": "./src",
-    "FLOW_LOADER": "./node_modules/@nodeproto/configproto/src/node/loaders/flow.mjs",
     "NODE_ENV": "production",
-    "NODE_OPTIONS_REMOVED": " --preserve-symlinks --preserve-symlinks-main   --v8-pool-size=0 --zero-fill-buffers",
-    "NODE_OPTIONS": "--abort-on-uncaught-exception --diagnostic-dir=\"/var/.nodeproto/diagnostics\" --enable-source-maps --experimental-abortcontroller --experimental-modules --experimental-import-meta-resolve --experimental-json-modules --experimental-loader=\"./node_modules/@nodeproto/configproto/src/node/loaders/flow.mjs\" --experimental-specifier-resolution=node --experimental-top-level-await --experimental-vm-modules --pending-deprecation --report-compact --report-dir=\"/var/.nodeproto/reports\" --report-filename=nodeprotolog --report-on-fatalerror --report-on-signal --report-signal=SIGUSR2 --report-uncaught-exception --trace-deprecation --trace-exit --trace-sigint --trace-uncaught --trace-warnings --unhandled-rejections=throw --use-largepages=on",
+    "NODE_OPTIONS": "--diagnostic-dir=\"/var/.nodeproto/node/diagnostics\" --report-compact --report-dir=\"/var/.nodeproto/node/reports\" --report-filename=node-report --report-on-fatalerror --report-on-signal --report-signal=SIGUSR2 --report-uncaught-exception --pending-deprecation --trace-deprecation --trace-exit --trace-sigint --trace-warnings --unhandled-rejections=strict --enable-source-maps --experimental-abortcontroller --experimental-fetch --experimental-import-meta-resolve --experimental-json-modules --experimental-loader=\"./node_modules/@nodeproto/configproto/src/node/loaders/flow.mjs\" --experimental-modules --experimental-specifier-resolution=node --experimental-top-level-await --tls-max-v1.3 --tls-min-v1.3 --use-largepages=on",
     "PATH_DIST": "./dist",
     "PATH_SRC": "./src"
   },
@@ -74,21 +69,14 @@
     "proto:script": "NODE_OPTIONS=\"$npm_package_config_NODE_OPTIONS\" pnpm -r $*",
     "proto:slice": "NODE_OPTIONS=\"$npm_package_config_NODE_OPTIONS\" pnpm exec ultra -r --filter",
     "proto": "pnpm exec ultra -r",
-    "repo:about:scripts": "npm run-script",
     "repo:about": "npm run-script && npm --versions && pnpm -r config list --json t && echo \"NODE OPTIONS set to: $npm_package_config_NODE_OPTIONS\"",
-    "repo:cp:browserslist": "rm -f .browserslistrc && cp ./node_modules/@nodeproto/configproto/.browserslistrc .",
-    "repo:cp:cjs": "rm -f ./dist/package.json && mkdir -p dist && cp ./node_modules/@nodeproto/configproto/src/node/cjs.json ./dist/package.json",
-    "repo:cp:configproto": "pnpm repo:cp:flow; pnpm repo:cp:cjs; pnpm repo:cp:browserslist; pnpm repo:cp:pretty",
-    "repo:cp:flow": "rm -f .flowconfig && cp ./node_modules/@nodeproto/configproto/.flowconfig .",
-    "repo:cp:pretty": "rm -f .prettier* && cp ./node_modules/@nodeproto/configproto/.prettier* .",
-    "repo:deps": "ultra --info",
     "repo:deps:direct": "npm ls",
-    "repo:update": "pnpm -r up --latest",
+    "repo:deps:graph": "ultra --info",
     "repo:eslint:fix": "pnpm repo:eslint -- --fix",
     "repo:eslint": "eslint './**/*'",
-    "repo:lint": "pnpm repo:eslint:fix; pnpm repo:flow:coverage",
     "repo:flow:coverage": "pnpm flow batch-coverage src",
     "repo:flowtyped:install": "flow-typed install",
+    "repo:lint": "pnpm repo:eslint:fix; pnpm repo:flow:coverage",
     "repo:monitor": "ultra --monitor",
     "repo:nuke": "pnpm repo:rm:dist; pnpm repo:rm:nodemodules",
     "repo:rm:dist": "rm -rf dist/*",
@@ -96,9 +84,9 @@
     "repo:scripts:v": "npm run-script",
     "repo:scripts": "ultra --list",
     "repo:test:file": "NODE_OPTIONS=\"$npm_package_config_NODE_OPTIONS\" node $*",
-    "repo:test:help": "uvu --help",
     "repo:test": "NODE_OPTIONS=\"$npm_package_config_NODE_OPTIONS\" uvu ./src \"test.(m|c)?js\"",
-    "repo:testing": "pnpm repo:test; chokidar \"src/**/*(?:.test)?.(m|c)?js\" -c \"pnpm repo:test\" -t 4000 -d 4000"
+    "repo:testing": "pnpm repo:test; chokidar \"src/**/*(?:.test)?.(m|c)?js\" -c \"pnpm repo:test\" -t 4000 -d 4000",
+    "repo:update": "pnpm up --latest"
   },
   "jsync": {
     "root": true

--- a/packages/apps/authnz/package.json
+++ b/packages/apps/authnz/package.json
@@ -17,14 +17,8 @@
     "url": "https://github.com/noahehall"
   },
   "config": {
-    "authnz_HTTP_PORT": "3000",
-    "authnz_HTTPS_PORT": "4430",
-    "BABEL_SHOW_CONFIG_FOR": "e.g. BABEL_SHOW_CONFIG_FOR=absolute/path/to/file somePkgJsonScriptName",
-    "DIRS_TO_TRANSPILE": "./src",
-    "FLOW_LOADER": "./node_modules/@nodeproto/configproto/src/node/loaders/flow.mjs",
     "NODE_ENV": "production",
-    "NODE_OPTIONS": "--abort-on-uncaught-exception --diagnostic-dir=\"/var/.nodeproto/diagnostics\" --enable-source-maps --experimental-abortcontroller --experimental-modules --experimental-import-meta-resolve --experimental-json-modules --experimental-loader=\"./node_modules/@nodeproto/configproto/src/node/loaders/flow.mjs\" --experimental-specifier-resolution=node --experimental-top-level-await --experimental-vm-modules --pending-deprecation --report-compact --report-dir=\"/var/.nodeproto/reports\" --report-filename=nodeprotolog --report-on-fatalerror --report-on-signal --report-signal=SIGUSR2 --report-uncaught-exception --trace-deprecation --trace-exit --trace-sigint --trace-uncaught --trace-warnings --unhandled-rejections=throw --use-largepages=on",
-    "NODE_OPTIONS_REMOVED": " --preserve-symlinks --preserve-symlinks-main   --v8-pool-size=0 --zero-fill-buffers",
+    "NODE_OPTIONS": "--diagnostic-dir=\"/var/.nodeproto/node/diagnostics\" --report-compact --report-dir=\"/var/.nodeproto/node/reports\" --report-filename=node-report --report-on-fatalerror --report-on-signal --report-signal=SIGUSR2 --report-uncaught-exception --pending-deprecation --trace-deprecation --trace-exit --trace-sigint --trace-warnings --unhandled-rejections=strict --enable-source-maps --experimental-abortcontroller --experimental-fetch --experimental-import-meta-resolve --experimental-json-modules --experimental-loader=\"./node_modules/@nodeproto/configproto/src/node/loaders/flow.mjs\" --experimental-modules --experimental-specifier-resolution=node --experimental-top-level-await --tls-max-v1.3 --tls-min-v1.3 --use-largepages=on",
     "PATH_DIST": "./dist",
     "PATH_SRC": "./src"
   },
@@ -96,7 +90,7 @@
     "src": "./src"
   },
   "engines": {
-    "node": "^14.17.0 || ^16.11.0 || >=17.5.0"
+    "node": "16.14.0 || 17.5.0"
   },
   "exports": {
     ".": {
@@ -152,20 +146,15 @@
     "linux"
   ],
   "scripts": {
-    "build": "clear; pnpm repo:rm:dist && NODE_OPTIONS=\"$npm_package_config_NODE_OPTIONS\" node esbuild.build.config.mjs && pnpm repo:cp:cjs",
+    "build": "NODE_ENV=production NODE_OPTIONS=\"$npm_package_config_NODE_OPTIONS\" pnpm repo:rm:dist &&  node esbuild.build.config.mjs",
     "proto": "pnpm exec ultra -r",
     "proto:bin": "pnpm -r exec $*",
     "proto:script": "NODE_OPTIONS=\"$npm_package_config_NODE_OPTIONS\" pnpm -r $*",
     "proto:slice": "NODE_OPTIONS=\"$npm_package_config_NODE_OPTIONS\" pnpm exec ultra -r --filter",
     "repo:about": "npm run-script && npm --versions && pnpm -r config list --json t && echo \"NODE OPTIONS set to: $npm_package_config_NODE_OPTIONS\"",
-    "repo:about:scripts": "npm run-script",
-    "repo:cp:browserslist": "rm -f .browserslistrc && cp ./node_modules/@nodeproto/configproto/.browserslistrc .",
-    "repo:cp:cjs": "rm -f ./dist/package.json && mkdir -p dist && cp ./node_modules/@nodeproto/configproto/src/node/cjs.json ./dist/package.json",
-    "repo:cp:configproto": "pnpm repo:cp:flow; pnpm repo:cp:cjs; pnpm repo:cp:browserslist; pnpm repo:cp:pretty",
-    "repo:cp:flow": "rm -f .flowconfig && cp ./node_modules/@nodeproto/configproto/.flowconfig .",
-    "repo:cp:pretty": "rm -f .prettier* && cp ./node_modules/@nodeproto/configproto/.prettier* .",
-    "repo:deps": "ultra --info",
+    "repo:cp:configproto": "cp ./node_modules/@nodeproto/configproto/{.browserslistrc,.flowconfig,.prettier*,} .",
     "repo:deps:direct": "npm ls",
+    "repo:deps:graph": "ultra --info",
     "repo:eslint": "eslint './**/*'",
     "repo:eslint:fix": "pnpm repo:eslint -- --fix",
     "repo:flow:coverage": "pnpm flow batch-coverage src",
@@ -180,9 +169,8 @@
     "repo:scripts:v": "npm run-script",
     "repo:test": "NODE_OPTIONS=\"$npm_package_config_NODE_OPTIONS\" uvu ./src \"test.(m|c)?js\"",
     "repo:test:file": "NODE_OPTIONS=\"$npm_package_config_NODE_OPTIONS\" node $*",
-    "repo:test:help": "uvu --help",
     "repo:testing": "pnpm repo:test; chokidar \"src/**/*(?:.test)?.(m|c)?js\" -c \"pnpm repo:test\" -t 4000 -d 4000",
-    "repo:update": "pnpm -r up --latest",
+    "repo:update": "pnpm up --latest",
     "start": "pnpm start:authnz",
     "start:authnz": "NODE_OPTIONS=\"$npm_package_config_NODE_OPTIONS\" node esbuild.run.config.mjs",
     "start:raw": "NODE_OPTIONS=\"$npm_package_config_NODE_OPTIONS\" node src/root.mjs"

--- a/packages/apps/client/package.json
+++ b/packages/apps/client/package.json
@@ -16,18 +16,10 @@
     "url": "https://github.com/noahehall"
   },
   "config": {
-    "BABEL_SHOW_CONFIG_FOR": "e.g. BABEL_SHOW_CONFIG_FOR=absolute/path/to/file somePkgJsonScriptName",
-    "CLIENT_PORT": "8080",
-    "DIRS_TO_TRANSPILE": "./src",
-    "FLOW_LOADER": "./node_modules/@nodeproto/configproto/src/node/loaders/flow.mjs",
-    "HTML_INDEX": "./app/index.html",
     "NODE_ENV": "production",
-    "NODE_OPTIONS": "--abort-on-uncaught-exception --diagnostic-dir=\"/var/.nodeproto/diagnostics\" --enable-source-maps --experimental-abortcontroller --experimental-modules --experimental-import-meta-resolve --experimental-json-modules --experimental-loader=\"./node_modules/@nodeproto/configproto/src/node/loaders/flow.mjs\" --experimental-specifier-resolution=node --experimental-top-level-await --experimental-vm-modules --pending-deprecation --report-compact --report-dir=\"/var/.nodeproto/reports\" --report-filename=nodeprotolog --report-on-fatalerror --report-on-signal --report-signal=SIGUSR2 --report-uncaught-exception --trace-deprecation --trace-exit --trace-sigint --trace-uncaught --trace-warnings --unhandled-rejections=throw --use-largepages=on",
-    "NODE_OPTIONS_REMOVED": " --preserve-symlinks --preserve-symlinks-main   --v8-pool-size=0 --zero-fill-buffers",
+    "NODE_OPTIONS": "--diagnostic-dir=\"/var/.nodeproto/node/diagnostics\" --report-compact --report-dir=\"/var/.nodeproto/node/reports\" --report-filename=node-report --report-on-fatalerror --report-on-signal --report-signal=SIGUSR2 --report-uncaught-exception --pending-deprecation --trace-deprecation --trace-exit --trace-sigint --trace-warnings --unhandled-rejections=strict --enable-source-maps --experimental-abortcontroller --experimental-fetch --experimental-import-meta-resolve --experimental-json-modules --experimental-loader=\"./node_modules/@nodeproto/configproto/src/node/loaders/flow.mjs\" --experimental-modules --experimental-specifier-resolution=node --experimental-top-level-await --tls-max-v1.3 --tls-min-v1.3 --use-largepages=on",
     "PATH_DIST": "./dist",
-    "PATH_SRC": "./src",
-    "REACT_APP_FILE": "./app/app.mjs",
-    "REACT_APP_ID": "root"
+    "PATH_SRC": "./src"
   },
   "dependencies": {
     "@babel/runtime": "7.17.2",
@@ -98,7 +90,7 @@
     "dist": "./dist"
   },
   "engines": {
-    "node": "^14.17.0 || ^16.11.0 || >=17.5.0"
+    "node": "16.14.0 || 17.5.0"
   },
   "jsync": {
     "root": false
@@ -154,14 +146,8 @@
     "proto:script": "NODE_OPTIONS=\"$npm_package_config_NODE_OPTIONS\" pnpm -r $*",
     "proto:slice": "NODE_OPTIONS=\"$npm_package_config_NODE_OPTIONS\" pnpm exec ultra -r --filter",
     "repo:about": "npm run-script && npm --versions && pnpm -r config list --json t && echo \"NODE OPTIONS set to: $npm_package_config_NODE_OPTIONS\"",
-    "repo:about:scripts": "npm run-script",
-    "repo:cp:browserslist": "rm -f .browserslistrc && cp ./node_modules/@nodeproto/configproto/.browserslistrc .",
-    "repo:cp:cjs": "rm -f ./dist/package.json && mkdir -p dist && cp ./node_modules/@nodeproto/configproto/src/node/cjs.json ./dist/package.json",
-    "repo:cp:configproto": "pnpm repo:cp:flow; pnpm repo:cp:cjs; pnpm repo:cp:browserslist; pnpm repo:cp:pretty",
-    "repo:cp:flow": "rm -f .flowconfig && cp ./node_modules/@nodeproto/configproto/.flowconfig .",
-    "repo:cp:pretty": "rm -f .prettier* && cp ./node_modules/@nodeproto/configproto/.prettier* .",
-    "repo:deps": "ultra --info",
     "repo:deps:direct": "npm ls",
+    "repo:deps:graph": "ultra --info",
     "repo:eslint": "eslint './**/*'",
     "repo:eslint:fix": "pnpm repo:eslint -- --fix",
     "repo:flow:coverage": "pnpm flow batch-coverage src",
@@ -176,9 +162,8 @@
     "repo:scripts:v": "npm run-script",
     "repo:test": "NODE_OPTIONS=\"$npm_package_config_NODE_OPTIONS\" uvu ./src \"test.(m|c)?js\"",
     "repo:test:file": "NODE_OPTIONS=\"$npm_package_config_NODE_OPTIONS\" node $*",
-    "repo:test:help": "uvu --help",
     "repo:testing": "pnpm repo:test; chokidar \"src/**/*(?:.test)?.(m|c)?js\" -c \"pnpm repo:test\" -t 4000 -d 4000",
-    "repo:update": "pnpm -r up --latest",
+    "repo:update": "pnpm up --latest",
     "start": "concurrently pnpm:start:dev pnpm:start:reactdevtools",
     "start:client": "pnpm start",
     "start:dev": "NODE_OPTIONS=\"$npm_package_config_NODE_OPTIONS\" node webpack.server.mjs",

--- a/packages/apps/gateway/package.json
+++ b/packages/apps/gateway/package.json
@@ -15,15 +15,8 @@
     "url": "https://github.com/noahehall"
   },
   "config": {
-    "DIRS_TO_TRANSPILE": "./src",
-    "FLOW_LOADER": "./node_modules/@nodeproto/configproto/src/node/loaders/flow.mjs",
-    "GATEWAY_CHROOT_DIR": "./var/lib/haproxy",
-    "GATEWAY_GROUP": "haproxy",
-    "GATEWAY_STATS_SOCK": "./run/haproxy/admin.sock",
-    "GATEWAY_USER": "haproxy",
     "NODE_ENV": "production",
-    "NODE_OPTIONS": "--abort-on-uncaught-exception --diagnostic-dir=\"/var/.nodeproto/diagnostics\" --enable-source-maps --experimental-abortcontroller --experimental-modules --experimental-import-meta-resolve --experimental-json-modules --experimental-loader=\"./node_modules/@nodeproto/configproto/src/node/loaders/flow.mjs\" --experimental-specifier-resolution=node --experimental-top-level-await --experimental-vm-modules --pending-deprecation --report-compact --report-dir=\"/var/.nodeproto/reports\" --report-filename=nodeprotolog --report-on-fatalerror --report-on-signal --report-signal=SIGUSR2 --report-uncaught-exception --trace-deprecation --trace-exit --trace-sigint --trace-uncaught --trace-warnings --unhandled-rejections=throw --use-largepages=on",
-    "NODE_OPTIONS_REMOVED": " --preserve-symlinks --preserve-symlinks-main   --v8-pool-size=0 --zero-fill-buffers",
+    "NODE_OPTIONS": "--diagnostic-dir=\"/var/.nodeproto/node/diagnostics\" --report-compact --report-dir=\"/var/.nodeproto/node/reports\" --report-filename=node-report --report-on-fatalerror --report-on-signal --report-signal=SIGUSR2 --report-uncaught-exception --pending-deprecation --trace-deprecation --trace-exit --trace-sigint --trace-warnings --unhandled-rejections=strict --enable-source-maps --experimental-abortcontroller --experimental-fetch --experimental-import-meta-resolve --experimental-json-modules --experimental-loader=\"./node_modules/@nodeproto/configproto/src/node/loaders/flow.mjs\" --experimental-modules --experimental-specifier-resolution=node --experimental-top-level-await --tls-max-v1.3 --tls-min-v1.3 --use-largepages=on",
     "PATH_DIST": "./dist",
     "PATH_SRC": "./src"
   },
@@ -42,7 +35,7 @@
     "src": "./src"
   },
   "engines": {
-    "node": "^14.17.0 || ^16.11.0 || >=17.5.0"
+    "node": "16.14.0 || 17.5.0"
   },
   "files": [
     ".editorconfig",
@@ -119,21 +112,7 @@
   ],
   "scripts": {
     "linkandsetowner": "src/usr/bin/linkandsetowner.sh",
-    "proto": "pnpm exec ultra -r",
-    "proto:bin": "pnpm -r exec $*",
-    "proto:script": "NODE_OPTIONS=\"$npm_package_config_NODE_OPTIONS\" pnpm -r $*",
-    "proto:slice": "NODE_OPTIONS=\"$npm_package_config_NODE_OPTIONS\" pnpm exec ultra -r --filter",
-    "repo:about": "npm run-script && npm --versions && pnpm -r config list --json t && echo \"NODE OPTIONS set to: $npm_package_config_NODE_OPTIONS\"",
-    "repo:about:scripts": "npm run-script",
-    "repo:deps": "ultra --info",
-    "repo:deps:direct": "npm ls",
     "repo:jsync": "jsync",
-    "repo:monitor": "ultra --monitor",
-    "repo:nuke": "pnpm repo:rm:dist; pnpm repo:rm:nodemodules",
-    "repo:rm:dist": "rm -rf dist/*",
-    "repo:rm:nodemodules": "rm -rf node_modules/*",
-    "repo:scripts": "ultra --list",
-    "repo:scripts:v": "npm run-script",
     "start": "src/usr/bin/startdefault.sh",
     "start:client": "pnpm start",
     "start:gateway": "pnpm start",

--- a/packages/configs/eslint-config/package.json
+++ b/packages/configs/eslint-config/package.json
@@ -3,9 +3,7 @@
   "version": "0.0.0",
   "description": "@nodeproto/eslint-config-node: nodejs servers ",
   "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
+  "scripts": {},
   "author": "",
   "license": "ISC",
   "dependencies": {

--- a/packages/configs/prettier-config/index.js
+++ b/packages/configs/prettier-config/index.js
@@ -17,4 +17,4 @@ module.exports = {
   "tabWidth": 2,
   "trailingComma": "es5",
   "useTabs": false
-}
+};

--- a/packages/configs/prettier-config/package.json
+++ b/packages/configs/prettier-config/package.json
@@ -3,9 +3,7 @@
   "version": "0.0.0",
   "description": "@nodeproto/prettier-config: full stack",
   "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
+  "scripts": {},
   "author": "",
   "license": "ISC",
   "peerDependencies": {

--- a/packages/libraries/buildproto/package.json
+++ b/packages/libraries/buildproto/package.json
@@ -4,8 +4,8 @@
   "homepage": "https://github.com/noahehall/nodeproto",
   "license": "SEE LICENSE IN LICENSE.md",
   "main": "./dist/index.js",
-  "name": "@nodeproto/buildproto",
   "module": "./src/index.mjs",
+  "name": "@nodeproto/buildproto",
   "packageManager": "pnpm@6.30.1",
   "private": true,
   "repository": "git://github.com/noahehall/nodeproto.git",
@@ -18,16 +18,10 @@
     "url": "https://github.com/noahehall"
   },
   "config": {
-    "BABEL_SHOW_CONFIG_FOR": "e.g. BABEL_SHOW_CONFIG_FOR=absolute/path/to/file somePkgJsonScriptName",
-    "DIRS_TO_TRANSPILE": "./src",
-    "FLOW_LOADER": "./node_modules/@nodeproto/configproto/src/node/loaders/flow.mjs",
     "NODE_ENV": "production",
-    "NODE_OPTIONS": "--abort-on-uncaught-exception --diagnostic-dir=\"/var/.nodeproto/diagnostics\" --enable-source-maps --experimental-abortcontroller --experimental-modules --experimental-import-meta-resolve --experimental-json-modules --experimental-loader=\"./node_modules/@nodeproto/configproto/src/node/loaders/flow.mjs\" --experimental-specifier-resolution=node --experimental-top-level-await --experimental-vm-modules --pending-deprecation --report-compact --report-dir=\"/var/.nodeproto/reports\" --report-filename=nodeprotolog --report-on-fatalerror --report-on-signal --report-signal=SIGUSR2 --report-uncaught-exception --trace-deprecation --trace-exit --trace-sigint --trace-uncaught --trace-warnings --unhandled-rejections=throw --use-largepages=on",
-    "NODE_OPTIONS_REMOVED": " --preserve-symlinks --preserve-symlinks-main   --v8-pool-size=0 --zero-fill-buffers",
+    "NODE_OPTIONS": "--diagnostic-dir=\"/var/.nodeproto/node/diagnostics\" --report-compact --report-dir=\"/var/.nodeproto/node/reports\" --report-filename=node-report --report-on-fatalerror --report-on-signal --report-signal=SIGUSR2 --report-uncaught-exception --pending-deprecation --trace-deprecation --trace-exit --trace-sigint --trace-warnings --unhandled-rejections=strict --enable-source-maps --experimental-abortcontroller --experimental-fetch --experimental-import-meta-resolve --experimental-json-modules --experimental-loader=\"./node_modules/@nodeproto/configproto/src/node/loaders/flow.mjs\" --experimental-modules --experimental-specifier-resolution=node --experimental-top-level-await --tls-max-v1.3 --tls-min-v1.3 --use-largepages=on",
     "PATH_DIST": "./dist",
-    "PATH_SRC": "./src",
-    "REMOVED_BABEL_OPTIONS": "--copy-files",
-    "REMOVED_NODE_OPTIONS": ""
+    "PATH_SRC": "./src"
   },
   "dependencies": {
     "@nodeproto/configproto": "workspace:0.0.0",
@@ -89,7 +83,7 @@
     "src": "./src"
   },
   "engines": {
-    "node": "^14.17.0 || ^16.11.0 || >=17.5.0"
+    "node": "16.14.0 || 17.5.0"
   },
   "exports": {
     ".": {
@@ -142,22 +136,14 @@
     "react-dom": "18.0.0-rc.0"
   },
   "scripts": {
-    "build": "pnpm repo:rm:dist && NODE_ENV=production NODE_OPTIONS=$npm_package_config_NODE_OPTIONS babel $npm_package_config_DIRS_TO_TRANSPILE -d $npm_package_config_PATH_DIST --out-file-extension .js --ignore 'src/**/*.test.mjs' --ignore src/webpack/test.compiler.mjs",
-    "clean": "pnpm repo:rm:dist && pnpm repo:cp:cjs",
-    "js:to:cjs": "for f in ./dist/**/*.js; do mv -- \"$f\" \"${f%.js}.cjs\"; done",
+    "build": "NODE_ENV=production NODE_OPTIONS=\"$npm_package_config_NODE_OPTIONS\" pnpm repo:rm:dist &&  babel $npm_package_config_PATH_SRC -d $npm_package_config_PATH_DIST --out-file-extension .js --ignore 'src/**/*.test.mjs'",
     "proto": "pnpm exec ultra -r",
     "proto:bin": "pnpm -r exec $*",
     "proto:script": "NODE_OPTIONS=\"$npm_package_config_NODE_OPTIONS\" pnpm -r $*",
     "proto:slice": "NODE_OPTIONS=\"$npm_package_config_NODE_OPTIONS\" pnpm exec ultra -r --filter",
     "repo:about": "npm run-script && npm --versions && pnpm -r config list --json t && echo \"NODE OPTIONS set to: $npm_package_config_NODE_OPTIONS\"",
-    "repo:about:scripts": "npm run-script",
-    "repo:cp:browserslist": "rm -f .browserslistrc && cp ./node_modules/@nodeproto/configproto/.browserslistrc .",
-    "repo:cp:cjs": "rm -f ./dist/package.json && mkdir -p dist && cp ./node_modules/@nodeproto/configproto/src/node/cjs.json ./dist/package.json",
-    "repo:cp:configproto": "pnpm repo:cp:flow; pnpm repo:cp:cjs; pnpm repo:cp:browserslist; pnpm repo:cp:pretty",
-    "repo:cp:flow": "rm -f .flowconfig && cp ./node_modules/@nodeproto/configproto/.flowconfig .",
-    "repo:cp:pretty": "rm -f .prettier* && cp ./node_modules/@nodeproto/configproto/.prettier* .",
-    "repo:deps": "ultra --info",
     "repo:deps:direct": "npm ls",
+    "repo:deps:graph": "ultra --info",
     "repo:eslint": "eslint './**/*'",
     "repo:eslint:fix": "pnpm repo:eslint -- --fix",
     "repo:flow:coverage": "pnpm flow batch-coverage src",
@@ -172,9 +158,8 @@
     "repo:scripts:v": "npm run-script",
     "repo:test": "NODE_OPTIONS=\"$npm_package_config_NODE_OPTIONS\" uvu ./src \"test.(m|c)?js\"",
     "repo:test:file": "NODE_OPTIONS=\"$npm_package_config_NODE_OPTIONS\" node $*",
-    "repo:test:help": "uvu --help",
     "repo:testing": "pnpm repo:test; chokidar \"src/**/*(?:.test)?.(m|c)?js\" -c \"pnpm repo:test\" -t 4000 -d 4000",
-    "repo:update": "pnpm -r up --latest"
+    "repo:update": "pnpm up --latest"
   },
   "ultra": {
     "concurrent": [

--- a/packages/libraries/buildproto/src/fixtures/json.json
+++ b/packages/libraries/buildproto/src/fixtures/json.json
@@ -1,0 +1,3 @@
+{
+  "i am": "a json file"
+}

--- a/packages/libraries/configproto/package.json
+++ b/packages/libraries/configproto/package.json
@@ -13,9 +13,7 @@
   "private": true,
   "sideEffects": false,
   "type": "module",
-  "engines": {
-    "node": "^14.17.0 || >=16.0.0 || >= 17.5"
-  },
+ "engines": { "node": "16.14.0 || 17.5.0" },
   "files": [
     "./src"
   ],
@@ -46,9 +44,8 @@
     "linux"
   ],
   "config": {
-    "DIRS_TO_TRANSPILE": "./src",
     "NODE_ENV": "production",
-    "NODE_OPTIONS": "--abort-on-uncaught-exception --diagnostic-dir=\"/var/.nodeproto/diagnostics\" --enable-source-maps --experimental-abortcontroller --experimental-modules --experimental-import-meta-resolve --experimental-json-modules --experimental-loader=\"./node_modules/@nodeproto/configproto/src/node/loaders/flow.mjs\" --experimental-specifier-resolution=node --experimental-top-level-await --experimental-vm-modules --pending-deprecation --report-compact --report-dir=\"/var/.nodeproto/reports\" --report-filename=nodeprotolog --report-on-fatalerror --report-on-signal --report-signal=SIGUSR2 --report-uncaught-exception --trace-deprecation --trace-exit --trace-sigint --trace-uncaught --trace-warnings --unhandled-rejections=throw --use-largepages=on",
+    "NODE_OPTIONS": "--diagnostic-dir=\"/var/.nodeproto/node/diagnostics\" --report-compact --report-dir=\"/var/.nodeproto/node/reports\" --report-filename=node-report --report-on-fatalerror --report-on-signal --report-signal=SIGUSR2 --report-uncaught-exception --pending-deprecation --trace-deprecation --trace-exit --trace-sigint --trace-warnings --unhandled-rejections=strict --enable-source-maps --experimental-abortcontroller --experimental-fetch --experimental-import-meta-resolve --experimental-json-modules --experimental-modules --experimental-specifier-resolution=node --experimental-top-level-await --tls-max-v1.3 --tls-min-v1.3 --use-largepages=on",
     "PATH_DIST": "./dist",
     "PATH_SRC": "./src"
   },
@@ -56,23 +53,24 @@
   "description": "static configuration files",
   "scripts": {
     "proto:bin": "pnpm -r exec $*",
-    "proto:script": "pnpm -r $*",
+    "proto:script": "NODE_OPTIONS=\"$npm_package_config_NODE_OPTIONS\" pnpm -r $*",
     "proto:slice": "NODE_OPTIONS=\"$npm_package_config_NODE_OPTIONS\" pnpm exec ultra -r --filter",
     "proto": "pnpm exec ultra -r",
-    "repo:about": "npm run-script && npm --versions && pnpm c list && echo \"NODE OPTIONS set to: $npm_package_config_NODE_OPTIONS\"",
-    "repo:deps": "ultra --info",
-    "repo:eslint": "eslint './**/*'",
+    "repo:about": "npm run-script && npm --versions && pnpm -r config list --json t && echo \"NODE OPTIONS set to: $npm_package_config_NODE_OPTIONS\"",
+    "repo:deps:direct": "npm ls",
+    "repo:deps:graph": "ultra --info",
     "repo:eslint:fix": "pnpm repo:eslint -- --fix",
-    "repo:lint": "pnpm repo:eslint:fix; pnpm repo:flow:coverage",
+    "repo:eslint": "eslint './**/*'",
     "repo:flow:coverage": "pnpm flow batch-coverage src",
     "repo:flowtyped:install": "flow-typed install",
+    "repo:lint": "pnpm repo:eslint:fix; pnpm repo:flow:coverage",
+    "repo:monitor": "ultra --monitor",
     "repo:nuke": "pnpm repo:rm:dist; pnpm repo:rm:nodemodules",
-    "repo:pretty:check": "pnpm prettier --check .",
-    "repo:pretty:write": "pnpm prettier --write .",
     "repo:rm:dist": "rm -rf dist/*",
     "repo:rm:nodemodules": "rm -rf node_modules/*",
     "repo:scripts:v": "npm run-script",
-    "repo:scripts": "ultra --list"
+    "repo:scripts": "ultra --list",
+    "repo:update": "pnpm up --latest"
   },
   "directories": {
     "src": "./src",
@@ -141,6 +139,20 @@
     "@babel/cli": "7.17.0",
     "@babel/core": "7.17.2",
     "eslint": "8.9.0",
-    "prettier": "2.5.1"
+    "prettier": "2.5.1",
+    "@babel/eslint-parser": "7.17.0",
+    "@babel/eslint-plugin": "7.16.5",
+    "@nodeproto/eslint-config": "workspace:0.0.0",
+    "@nodeproto/prettier-config": "workspace:0.0.0",
+    "eslint-config-prettier": "8.3.0",
+    "eslint-plugin-fb-flow": "0.0.4",
+    "eslint-plugin-flowtype-errors": "4.5.0",
+    "eslint-plugin-html": "6.2.0",
+    "eslint-plugin-json": "3.1.0",
+    "eslint-plugin-markdown": "2.2.1",
+    "eslint-plugin-node": "11.1.0",
+    "eslint-plugin-prettier": "4.0.0",
+    "eslint-plugin-promise": "6.0.0",
+    "eslint-plugin-yml": "0.13.0"
   }
 }

--- a/packages/libraries/envproto/package.json
+++ b/packages/libraries/envproto/package.json
@@ -18,12 +18,8 @@
     "url": "https://github.com/noahehall"
   },
   "config": {
-    "BABEL_SHOW_CONFIG_FOR": "e.g. BABEL_SHOW_CONFIG_FOR=absolute/path/to/file somePkgJsonScriptName",
-    "DIRS_TO_TRANSPILE": "./src",
-    "FLOW_LOADER": "./node_modules/@nodeproto/configproto/src/node/loaders/flow.mjs",
     "NODE_ENV": "production",
-    "NODE_OPTIONS": "--abort-on-uncaught-exception --diagnostic-dir=\"/var/.nodeproto/diagnostics\" --enable-source-maps --experimental-abortcontroller --experimental-modules --experimental-import-meta-resolve --experimental-json-modules --experimental-loader=\"./node_modules/@nodeproto/configproto/src/node/loaders/flow.mjs\" --experimental-specifier-resolution=node --experimental-top-level-await --experimental-vm-modules --pending-deprecation --report-compact --report-dir=\"/var/.nodeproto/reports\" --report-filename=nodeprotolog --report-on-fatalerror --report-on-signal --report-signal=SIGUSR2 --report-uncaught-exception --trace-deprecation --trace-exit --trace-sigint --trace-uncaught --trace-warnings --unhandled-rejections=throw --use-largepages=on",
-    "NODE_OPTIONS_REMOVED": " --preserve-symlinks --preserve-symlinks-main   --v8-pool-size=0 --zero-fill-buffers",
+    "NODE_OPTIONS": "--diagnostic-dir=\"/var/.nodeproto/node/diagnostics\" --report-compact --report-dir=\"/var/.nodeproto/node/reports\" --report-filename=node-report --report-on-fatalerror --report-on-signal --report-signal=SIGUSR2 --report-uncaught-exception --pending-deprecation --trace-deprecation --trace-exit --trace-sigint --trace-warnings --unhandled-rejections=strict --enable-source-maps --experimental-abortcontroller --experimental-fetch --experimental-import-meta-resolve --experimental-json-modules --experimental-loader=\"./node_modules/@nodeproto/configproto/src/node/loaders/flow.mjs\" --experimental-modules --experimental-specifier-resolution=node --experimental-top-level-await --tls-max-v1.3 --tls-min-v1.3 --use-largepages=on",
     "PATH_DIST": "./dist",
     "PATH_SRC": "./src"
   },
@@ -72,7 +68,7 @@
     "src": "./src"
   },
   "engines": {
-    "node": "^14.17.0 || ^16.11.0 || >=17.5.0"
+    "node": "16.14.0 || 17.5.0"
   },
   "exports": {
     ".": {
@@ -130,20 +126,14 @@
     "linux"
   ],
   "scripts": {
-    "build": "NODE_ENV=production NODE_OPTIONS=\"$npm_package_config_NODE_OPTIONS\" pnpm repo:rm:dist && pnpm repo:cp:cjs && babel $npm_package_config_DIRS_TO_TRANSPILE -d $npm_package_config_PATH_DIST --copy-files --no-copy-ignored --ignore \"**/*.test.mjs\"",
+    "build": "NODE_ENV=production NODE_OPTIONS=\"$npm_package_config_NODE_OPTIONS\" pnpm repo:rm:dist && babel $npm_package_config_PATH_SRC -d $npm_package_config_PATH_DIST --copy-files --no-copy-ignored --ignore \"**/*.test.mjs\"",
     "proto": "pnpm exec ultra -r",
     "proto:bin": "pnpm -r exec $*",
     "proto:script": "NODE_OPTIONS=\"$npm_package_config_NODE_OPTIONS\" pnpm -r $*",
     "proto:slice": "NODE_OPTIONS=\"$npm_package_config_NODE_OPTIONS\" pnpm exec ultra -r --filter",
     "repo:about": "npm run-script && npm --versions && pnpm -r config list --json t && echo \"NODE OPTIONS set to: $npm_package_config_NODE_OPTIONS\"",
-    "repo:about:scripts": "npm run-script",
-    "repo:cp:browserslist": "rm -f .browserslistrc && cp ./node_modules/@nodeproto/configproto/.browserslistrc .",
-    "repo:cp:cjs": "rm -f ./dist/package.json && mkdir -p dist && cp ./node_modules/@nodeproto/configproto/src/node/cjs.json ./dist/package.json",
-    "repo:cp:configproto": "pnpm repo:cp:flow; pnpm repo:cp:cjs; pnpm repo:cp:browserslist; pnpm repo:cp:pretty",
-    "repo:cp:flow": "rm -f .flowconfig && cp ./node_modules/@nodeproto/configproto/.flowconfig .",
-    "repo:cp:pretty": "rm -f .prettier* && cp ./node_modules/@nodeproto/configproto/.prettier* .",
-    "repo:deps": "ultra --info",
     "repo:deps:direct": "npm ls",
+    "repo:deps:graph": "ultra --info",
     "repo:eslint": "eslint './**/*'",
     "repo:eslint:fix": "pnpm repo:eslint -- --fix",
     "repo:flow:coverage": "pnpm flow batch-coverage src",
@@ -158,9 +148,8 @@
     "repo:scripts:v": "npm run-script",
     "repo:test": "NODE_OPTIONS=\"$npm_package_config_NODE_OPTIONS\" uvu ./src \"test.(m|c)?js\"",
     "repo:test:file": "NODE_OPTIONS=\"$npm_package_config_NODE_OPTIONS\" node $*",
-    "repo:test:help": "uvu --help",
     "repo:testing": "pnpm repo:test; chokidar \"src/**/*(?:.test)?.(m|c)?js\" -c \"pnpm repo:test\" -t 4000 -d 4000",
-    "repo:update": "pnpm -r up --latest"
+    "repo:update": "pnpm up --latest"
   },
   "ultra": {
     "concurrent": [

--- a/packages/libraries/shared/package.json
+++ b/packages/libraries/shared/package.json
@@ -13,9 +13,7 @@
   "sideEffects": false,
   "type": "module",
   "version": "0.0.0",
-  "engines": {
-    "node": "^14.17.0 || >=16.0.0 || >= 17.5"
-  },
+  "engines": { "node": "16.14.0 || 17.5.0" },
   "keywords": [
     "@nirv",
     "@nodeproto",
@@ -43,9 +41,8 @@
     "linux"
   ],
   "config": {
-    "DIRS_TO_TRANSPILE": "./src",
     "NODE_ENV": "production",
-    "NODE_OPTIONS": "--abort-on-uncaught-exception --diagnostic-dir=\"/var/.nodeproto/diagnostics\" --enable-source-maps --experimental-abortcontroller --experimental-modules --experimental-import-meta-resolve --experimental-json-modules --experimental-loader=\"./node_modules/@nodeproto/configproto/src/node/loaders/flow.mjs\" --experimental-specifier-resolution=node --experimental-top-level-await --experimental-vm-modules --pending-deprecation --report-compact --report-dir=\"/var/.nodeproto/reports\" --report-filename=nodeprotolog --report-on-fatalerror --report-on-signal --report-signal=SIGUSR2 --report-uncaught-exception --trace-deprecation --trace-exit --trace-sigint --trace-uncaught --trace-warnings --unhandled-rejections=throw --use-largepages=on",
+    "NODE_OPTIONS": "--diagnostic-dir=\"/var/.nodeproto/node/diagnostics\" --report-compact --report-dir=\"/var/.nodeproto/node/reports\" --report-filename=node-report --report-on-fatalerror --report-on-signal --report-signal=SIGUSR2 --report-uncaught-exception --pending-deprecation --trace-deprecation --trace-exit --trace-sigint --trace-warnings --unhandled-rejections=strict --enable-source-maps --experimental-abortcontroller --experimental-fetch --experimental-import-meta-resolve --experimental-json-modules --experimental-loader=\"./node_modules/@nodeproto/configproto/src/node/loaders/flow.mjs\" --experimental-modules --experimental-specifier-resolution=node --experimental-top-level-await --tls-max-v1.3 --tls-min-v1.3 --use-largepages=on",
     "PATH_DIST": "./dist",
     "PATH_SRC": "./src"
   },
@@ -84,32 +81,29 @@
     "./.flowconfig"
   ],
   "scripts": {
-    "build": "NODE_ENV=production NODE_OPTIONS=\"$npm_package_config_NODE_OPTIONS\" pnpm repo:rm:dist && pnpm repo:cp:cjs && babel $npm_package_config_DIRS_TO_TRANSPILE -d $npm_package_config_PATH_DIST --copy-files --no-copy-ignored --ignore \"**/*.test.mjs\"",
+    "build": "NODE_ENV=production NODE_OPTIONS=\"$npm_package_config_NODE_OPTIONS\" pnpm repo:rm:dist && babel $npm_package_config_PATH_SRC -d $npm_package_config_PATH_DIST --copy-files --no-copy-ignored --ignore \"**/*.test.mjs\"",
     "proto:bin": "pnpm -r exec $*",
-    "proto:script": "pnpm -r $*",
+    "proto:script": "NODE_OPTIONS=\"$npm_package_config_NODE_OPTIONS\" pnpm -r $*",
     "proto:slice": "NODE_OPTIONS=\"$npm_package_config_NODE_OPTIONS\" pnpm exec ultra -r --filter",
     "proto": "pnpm exec ultra -r",
-    "repo:about": "npm run-script && npm --versions && pnpm c list && echo \"NODE OPTIONS set to: $npm_package_config_NODE_OPTIONS\"",
-    "repo:cp:browserslist": "rm -f .browserslistrc && cp ./node_modules/@nodeproto/configproto/.browserslistrc .",
-    "repo:cp:cjs": "rm -f ./dist/package.json && mkdir -p dist && cp ./node_modules/@nodeproto/configproto/src/node/cjs.json ./dist/package.json",
-    "repo:cp:configproto": "pnpm repo:cp:flow; pnpm repo:cp:cjs; pnpm repo:cp:browserslist; pnpm repo:cp:pretty",
-    "repo:cp:flow": "rm -f .flowconfig && cp ./node_modules/@nodeproto/configproto/.flowconfig .",
-    "repo:cp:pretty": "rm -f .prettier* && cp ./node_modules/@nodeproto/configproto/.prettier* .",
-    "repo:deps": "ultra --info",
+    "repo:about": "npm run-script && npm --versions && pnpm -r config list --json t && echo \"NODE OPTIONS set to: $npm_package_config_NODE_OPTIONS\"",
+    "repo:deps:direct": "npm ls",
+    "repo:deps:graph": "ultra --info",
     "repo:eslint:fix": "pnpm repo:eslint -- --fix",
     "repo:eslint": "eslint './**/*'",
-    "repo:lint": "pnpm repo:eslint:fix; pnpm repo:flow:coverage",
     "repo:flow:coverage": "pnpm flow batch-coverage src",
     "repo:flowtyped:install": "flow-typed install",
+    "repo:lint": "pnpm repo:eslint:fix; pnpm repo:flow:coverage",
+    "repo:monitor": "ultra --monitor",
     "repo:nuke": "pnpm repo:rm:dist; pnpm repo:rm:nodemodules",
     "repo:rm:dist": "rm -rf dist/*",
     "repo:rm:nodemodules": "rm -rf node_modules/*",
     "repo:scripts:v": "npm run-script",
     "repo:scripts": "ultra --list",
-    "repo:test:file": "node --experimental-specifier-resolution=node --experimental-import-meta-resolve $*",
-    "repo:test:help": "uvu --help",
+    "repo:test:file": "NODE_OPTIONS=\"$npm_package_config_NODE_OPTIONS\" node $*",
     "repo:test": "NODE_OPTIONS=\"$npm_package_config_NODE_OPTIONS\" uvu ./src \"test.(m|c)?js\"",
-    "repo:testing": "pnpm repo:test; chokidar \"src/**/*(?:.test)?.(m|c)?js\" -c \"pnpm repo:test\" -t 1500"
+    "repo:testing": "pnpm repo:test; chokidar \"src/**/*(?:.test)?.(m|c)?js\" -c \"pnpm repo:test\" -t 4000 -d 4000",
+    "repo:update": "pnpm up --latest"
   },
   "dependencies": {
     "@babel/runtime": "7.17.2",

--- a/packages/libraries/testproto/package.json
+++ b/packages/libraries/testproto/package.json
@@ -22,10 +22,9 @@
   ],
   "config": {
     "NODE_ENV": "production",
-    "NODE_OPTIONS": "--abort-on-uncaught-exception --diagnostic-dir=\"/var/.nodeproto/diagnostics\" --enable-source-maps --experimental-abortcontroller --experimental-modules --experimental-import-meta-resolve --experimental-json-modules --experimental-loader=\"./node_modules/@nodeproto/configproto/src/node/loaders/flow.mjs\" --experimental-specifier-resolution=node --experimental-top-level-await --experimental-vm-modules --pending-deprecation --report-compact --report-dir=\"/var/.nodeproto/reports\" --report-filename=nodeprotolog --report-on-fatalerror --report-on-signal --report-signal=SIGUSR2 --report-uncaught-exception --trace-deprecation --trace-exit --trace-sigint --trace-uncaught --trace-warnings --unhandled-rejections=throw --use-largepages=on",
+    "NODE_OPTIONS": "--diagnostic-dir=\"/var/.nodeproto/node/diagnostics\" --report-compact --report-dir=\"/var/.nodeproto/node/reports\" --report-filename=node-report --report-on-fatalerror --report-on-signal --report-signal=SIGUSR2 --report-uncaught-exception --pending-deprecation --trace-deprecation --trace-exit --trace-sigint --trace-warnings --unhandled-rejections=strict --enable-source-maps --experimental-abortcontroller --experimental-fetch --experimental-import-meta-resolve --experimental-json-modules --experimental-loader=\"./node_modules/@nodeproto/configproto/src/node/loaders/flow.mjs\" --experimental-modules --experimental-specifier-resolution=node --experimental-top-level-await --tls-max-v1.3 --tls-min-v1.3 --use-largepages=on",
     "PATH_DIST": "./dist",
-    "PATH_SRC": "./src",
-    "DIRS_TO_TRANSPILE": "./src"
+    "PATH_SRC": "./src"
   },
   "dependencies": {
     "@babel/runtime": "7.17.2",
@@ -85,36 +84,31 @@
     "darwin",
     "linux"
   ],
-  "engines": {
-    "node": "^14.17.0 || >=16.0.0 || >=17.5"
-  },
+  "engines": { "node": "16.14.0 || 17.5.0" },
   "scripts": {
-    "build": "NODE_ENV=production NODE_OPTIONS=\"$npm_package_config_NODE_OPTIONS\" pnpm repo:rm:dist && pnpm repo:cp:cjs && babel $npm_package_config_DIRS_TO_TRANSPILE -d $npm_package_config_PATH_DIST --copy-files --no-copy-ignored --ignore \"**/*.test.mjs\"",
+    "build": "NODE_ENV=production NODE_OPTIONS=\"$npm_package_config_NODE_OPTIONS\" pnpm repo:rm:dist && babel $npm_package_config_PATH_SRC -d $npm_package_config_PATH_DIST --copy-files --no-copy-ignored --ignore \"**/*.test.mjs\"",
     "proto:bin": "pnpm -r exec $*",
-    "proto:script": "pnpm -r $*",
+    "proto:script": "NODE_OPTIONS=\"$npm_package_config_NODE_OPTIONS\" pnpm -r $*",
     "proto:slice": "NODE_OPTIONS=\"$npm_package_config_NODE_OPTIONS\" pnpm exec ultra -r --filter",
     "proto": "pnpm exec ultra -r",
-    "repo:about": "npm run-script && npm --versions && pnpm c list && echo \"NODE OPTIONS set to: $npm_package_config_NODE_OPTIONS\"",
-    "repo:cp:browserslist": "rm -f .browserslistrc && cp ./node_modules/@nodeproto/configproto/.browserslistrc .",
-    "repo:cp:cjs": "rm -f ./dist/package.json && mkdir -p dist && cp ./node_modules/@nodeproto/configproto/src/node/cjs.json ./dist/package.json",
-    "repo:cp:configproto": "pnpm repo:cp:flow; pnpm repo:cp:cjs; pnpm repo:cp:browserslist; pnpm repo:cp:pretty",
-    "repo:cp:flow": "rm -f .flowconfig && cp ./node_modules/@nodeproto/configproto/.flowconfig .",
-    "repo:cp:pretty": "rm -f .prettier* && cp ./node_modules/@nodeproto/configproto/.prettier* .",
-    "repo:deps": "ultra --info",
+    "repo:about": "npm run-script && npm --versions && pnpm -r config list --json t && echo \"NODE OPTIONS set to: $npm_package_config_NODE_OPTIONS\"",
+    "repo:deps:direct": "npm ls",
+    "repo:deps:graph": "ultra --info",
     "repo:eslint:fix": "pnpm repo:eslint -- --fix",
     "repo:eslint": "eslint './**/*'",
-    "repo:lint": "pnpm repo:eslint:fix; pnpm repo:flow:coverage",
     "repo:flow:coverage": "pnpm flow batch-coverage src",
     "repo:flowtyped:install": "flow-typed install",
+    "repo:lint": "pnpm repo:eslint:fix; pnpm repo:flow:coverage",
+    "repo:monitor": "ultra --monitor",
     "repo:nuke": "pnpm repo:rm:dist; pnpm repo:rm:nodemodules",
     "repo:rm:dist": "rm -rf dist/*",
     "repo:rm:nodemodules": "rm -rf node_modules/*",
     "repo:scripts:v": "npm run-script",
     "repo:scripts": "ultra --list",
     "repo:test:file": "NODE_OPTIONS=\"$npm_package_config_NODE_OPTIONS\" node $*",
-    "repo:test:help": "uvu --help",
     "repo:test": "NODE_OPTIONS=\"$npm_package_config_NODE_OPTIONS\" uvu ./src \"test.(m|c)?js\"",
-    "repo:testing": "pnpm repo:test; chokidar \"src/**/*(?:.test)?.(m|c)?js\" -c \"pnpm repo:test\""
+    "repo:testing": "pnpm repo:test; chokidar \"src/**/*(?:.test)?.(m|c)?js\" -c \"pnpm repo:test\" -t 4000 -d 4000",
+    "repo:update": "pnpm up --latest"
   },
   "peerDependencies": {
     "chokidar-cli": "3.0.0",

--- a/packages/libraries/wtf/package.json
+++ b/packages/libraries/wtf/package.json
@@ -18,12 +18,8 @@
     "url": "https://github.com/noahehall"
   },
   "config": {
-    "BABEL_SHOW_CONFIG_FOR": "e.g. BABEL_SHOW_CONFIG_FOR=absolute/path/to/file somePkgJsonScriptName",
-    "DIRS_TO_TRANSPILE": "./src",
-    "FLOW_LOADER": "./node_modules/@nodeproto/configproto/src/node/loaders/flow.mjs",
     "NODE_ENV": "production",
-    "NODE_OPTIONS": "--abort-on-uncaught-exception --diagnostic-dir=\"/var/.nodeproto/diagnostics\" --enable-source-maps --experimental-abortcontroller --experimental-modules --experimental-import-meta-resolve --experimental-json-modules --experimental-loader=\"./node_modules/@nodeproto/configproto/src/node/loaders/flow.mjs\" --experimental-specifier-resolution=node --experimental-top-level-await --experimental-vm-modules --pending-deprecation --report-compact --report-dir=\"/var/.nodeproto/reports\" --report-filename=nodeprotolog --report-on-fatalerror --report-on-signal --report-signal=SIGUSR2 --report-uncaught-exception --trace-deprecation --trace-exit --trace-sigint --trace-uncaught --trace-warnings --unhandled-rejections=throw --use-largepages=on",
-    "NODE_OPTIONS_REMOVED": " --preserve-symlinks --preserve-symlinks-main   --v8-pool-size=0 --zero-fill-buffers",
+    "NODE_OPTIONS": "--diagnostic-dir=\"/var/.nodeproto/node/diagnostics\" --report-compact --report-dir=\"/var/.nodeproto/node/reports\" --report-filename=node-report --report-on-fatalerror --report-on-signal --report-signal=SIGUSR2 --report-uncaught-exception --pending-deprecation --trace-deprecation --trace-exit --trace-sigint --trace-warnings --unhandled-rejections=strict --enable-source-maps --experimental-abortcontroller --experimental-fetch --experimental-import-meta-resolve --experimental-json-modules --experimental-loader=\"./node_modules/@nodeproto/configproto/src/node/loaders/flow.mjs\" --experimental-modules --experimental-specifier-resolution=node --experimental-top-level-await --tls-max-v1.3 --tls-min-v1.3 --use-largepages=on",
     "PATH_DIST": "./dist",
     "PATH_SRC": "./src"
   },
@@ -77,7 +73,7 @@
     "src": "./src"
   },
   "engines": {
-    "node": "^14.17.0 || ^16.11.0 || >=17.5.0"
+    "node": "16.14.0 || 17.5.0"
   },
   "exports": {
     ".": {
@@ -143,20 +139,14 @@
     "linux"
   ],
   "scripts": {
-    "build": "NODE_ENV=production NODE_OPTIONS=\"$npm_package_config_NODE_OPTIONS\" pnpm repo:rm:dist && pnpm repo:cp:cjs && babel $npm_package_config_DIRS_TO_TRANSPILE -d $npm_package_config_PATH_DIST --copy-files --no-copy-ignored --ignore \"**/*.test.mjs\"",
+    "build": "NODE_ENV=production NODE_OPTIONS=\"$npm_package_config_NODE_OPTIONS\" pnpm repo:rm:dist && babel $npm_package_config_PATH_SRC -d $npm_package_config_PATH_DIST --copy-files --no-copy-ignored --ignore \"**/*.test.mjs\"",
     "proto": "pnpm exec ultra -r",
     "proto:bin": "pnpm -r exec $*",
     "proto:script": "NODE_OPTIONS=\"$npm_package_config_NODE_OPTIONS\" pnpm -r $*",
     "proto:slice": "NODE_OPTIONS=\"$npm_package_config_NODE_OPTIONS\" pnpm exec ultra -r --filter",
     "repo:about": "npm run-script && npm --versions && pnpm -r config list --json t && echo \"NODE OPTIONS set to: $npm_package_config_NODE_OPTIONS\"",
-    "repo:about:scripts": "npm run-script",
-    "repo:cp:browserslist": "rm -f .browserslistrc && cp ./node_modules/@nodeproto/configproto/.browserslistrc .",
-    "repo:cp:cjs": "rm -f ./dist/package.json && mkdir -p dist && cp ./node_modules/@nodeproto/configproto/src/node/cjs.json ./dist/package.json",
-    "repo:cp:configproto": "pnpm repo:cp:flow; pnpm repo:cp:cjs; pnpm repo:cp:browserslist; pnpm repo:cp:pretty",
-    "repo:cp:flow": "rm -f .flowconfig && cp ./node_modules/@nodeproto/configproto/.flowconfig .",
-    "repo:cp:pretty": "rm -f .prettier* && cp ./node_modules/@nodeproto/configproto/.prettier* .",
-    "repo:deps": "ultra --info",
     "repo:deps:direct": "npm ls",
+    "repo:deps:graph": "ultra --info",
     "repo:eslint": "eslint './**/*'",
     "repo:eslint:fix": "pnpm repo:eslint -- --fix",
     "repo:flow:coverage": "pnpm flow batch-coverage src",
@@ -171,9 +161,8 @@
     "repo:scripts:v": "npm run-script",
     "repo:test": "NODE_OPTIONS=\"$npm_package_config_NODE_OPTIONS\" uvu ./src \"test.(m|c)?js\"",
     "repo:test:file": "NODE_OPTIONS=\"$npm_package_config_NODE_OPTIONS\" node $*",
-    "repo:test:help": "uvu --help",
     "repo:testing": "pnpm repo:test; chokidar \"src/**/*(?:.test)?.(m|c)?js\" -c \"pnpm repo:test\" -t 4000 -d 4000",
-    "repo:update": "pnpm -r up --latest"
+    "repo:update": "pnpm up --latest"
   },
   "ultra": {
     "concurrent": [

--- a/packages/tools/bodyguard/package.json
+++ b/packages/tools/bodyguard/package.json
@@ -15,12 +15,8 @@
     "url": "https://github.com/noahehall"
   },
   "config": {
-    "BABEL_SHOW_CONFIG_FOR": "e.g. BABEL_SHOW_CONFIG_FOR=absolute/path/to/file somePkgJsonScriptName",
-    "DIRS_TO_TRANSPILE": "./src",
-    "FLOW_LOADER": "./node_modules/@nodeproto/configproto/src/node/loaders/flow.mjs",
     "NODE_ENV": "production",
-    "NODE_OPTIONS": "--abort-on-uncaught-exception --diagnostic-dir=\"/var/.nodeproto/diagnostics\" --enable-source-maps --experimental-abortcontroller --experimental-modules --experimental-import-meta-resolve --experimental-json-modules --experimental-loader=\"./node_modules/@nodeproto/configproto/src/node/loaders/flow.mjs\" --experimental-specifier-resolution=node --experimental-top-level-await --experimental-vm-modules --pending-deprecation --report-compact --report-dir=\"/var/.nodeproto/reports\" --report-filename=nodeprotolog --report-on-fatalerror --report-on-signal --report-signal=SIGUSR2 --report-uncaught-exception --trace-deprecation --trace-exit --trace-sigint --trace-uncaught --trace-warnings --unhandled-rejections=throw --use-largepages=on",
-    "NODE_OPTIONS_REMOVED": " --preserve-symlinks --preserve-symlinks-main   --v8-pool-size=0 --zero-fill-buffers",
+    "NODE_OPTIONS": "--diagnostic-dir=\"/var/.nodeproto/node/diagnostics\" --report-compact --report-dir=\"/var/.nodeproto/node/reports\" --report-filename=node-report --report-on-fatalerror --report-on-signal --report-signal=SIGUSR2 --report-uncaught-exception --pending-deprecation --trace-deprecation --trace-exit --trace-sigint --trace-warnings --unhandled-rejections=strict --enable-source-maps --experimental-abortcontroller --experimental-fetch --experimental-import-meta-resolve --experimental-json-modules --experimental-loader=\"./node_modules/@nodeproto/configproto/src/node/loaders/flow.mjs\" --experimental-modules --experimental-specifier-resolution=node --experimental-top-level-await --tls-max-v1.3 --tls-min-v1.3 --use-largepages=on",
     "PATH_DIST": "./dist",
     "PATH_SRC": "./src"
   },
@@ -34,10 +30,8 @@
     "download": "8.0.0",
     "env-cmd": "10.1.0",
     "express": "4.17.2",
-    "globby": "13.1.1",
     "react": "18.0.0-rc.0",
     "react-dom": "18.0.0-rc.0",
-    "safe-compare": "1.1.4",
     "ultra-runner": "3.10.5"
   },
   "devDependencies": {
@@ -81,7 +75,7 @@
     "yaml-eslint-parser": "0.5.0"
   },
   "engines": {
-    "node": "^14.17.0 || ^16.11.0 || >=17.5.0"
+    "node": "16.14.0 || 17.5.0"
   },
   "files": [
     "dist",
@@ -133,21 +127,15 @@
     "linux"
   ],
   "scripts": {
-    "build": "rm -rf ./dist/* && NODE_OPTIONS=\"$npm_package_config_NODE_OPTIONS\" node react.webpack.config.mjs",
+    "build": "NODE_ENV=production NODE_OPTIONS=\"$npm_package_config_NODE_OPTIONS\" node react.webpack.config.mjs",
     "build:w": "WATCH=1 pnpm build",
     "proto": "pnpm exec ultra -r",
     "proto:bin": "pnpm -r exec $*",
     "proto:script": "NODE_OPTIONS=\"$npm_package_config_NODE_OPTIONS\" pnpm -r $*",
     "proto:slice": "NODE_OPTIONS=\"$npm_package_config_NODE_OPTIONS\" pnpm exec ultra -r --filter",
     "repo:about": "npm run-script && npm --versions && pnpm -r config list --json t && echo \"NODE OPTIONS set to: $npm_package_config_NODE_OPTIONS\"",
-    "repo:about:scripts": "npm run-script",
-    "repo:cp:browserslist": "rm -f .browserslistrc && cp ./node_modules/@nodeproto/configproto/.browserslistrc .",
-    "repo:cp:cjs": "rm -f ./dist/package.json && mkdir -p dist && cp ./node_modules/@nodeproto/configproto/src/node/cjs.json ./dist/package.json",
-    "repo:cp:configproto": "pnpm repo:cp:flow; pnpm repo:cp:cjs; pnpm repo:cp:browserslist; pnpm repo:cp:pretty",
-    "repo:cp:flow": "rm -f .flowconfig && cp ./node_modules/@nodeproto/configproto/.flowconfig .",
-    "repo:cp:pretty": "rm -f .prettier* && cp ./node_modules/@nodeproto/configproto/.prettier* .",
-    "repo:deps": "ultra --info",
     "repo:deps:direct": "npm ls",
+    "repo:deps:graph": "ultra --info",
     "repo:eslint": "eslint './**/*'",
     "repo:eslint:fix": "pnpm repo:eslint -- --fix",
     "repo:flow:coverage": "pnpm flow batch-coverage src",
@@ -162,9 +150,8 @@
     "repo:scripts:v": "npm run-script",
     "repo:test": "NODE_OPTIONS=\"$npm_package_config_NODE_OPTIONS\" uvu ./src \"test.(m|c)?js\"",
     "repo:test:file": "NODE_OPTIONS=\"$npm_package_config_NODE_OPTIONS\" node $*",
-    "repo:test:help": "uvu --help",
     "repo:testing": "pnpm repo:test; chokidar \"src/**/*(?:.test)?.(m|c)?js\" -c \"pnpm repo:test\" -t 4000 -d 4000",
-    "repo:update": "pnpm -r up --latest",
+    "repo:update": "pnpm up --latest",
     "start:chrome": "web-ext run --bc -t chromium",
     "webext:lint": "pnpm exec web-ext -c=config.cjs lint",
     "webext:run": "pnpm exec web-ext -c=config.cjs run --verbose",

--- a/packages/tools/jsync/package.json
+++ b/packages/tools/jsync/package.json
@@ -19,12 +19,8 @@
     "jsync": "./bin/jsync.js"
   },
   "config": {
-    "BABEL_SHOW_CONFIG_FOR": "e.g. BABEL_SHOW_CONFIG_FOR=absolute/path/to/file somePkgJsonScriptName",
-    "DIRS_TO_TRANSPILE": "./src",
-    "FLOW_LOADER": "./node_modules/@nodeproto/configproto/src/node/loaders/flow.mjs",
     "NODE_ENV": "production",
-    "NODE_OPTIONS": "--abort-on-uncaught-exception --diagnostic-dir=\"/var/.nodeproto/diagnostics\" --enable-source-maps --experimental-abortcontroller --experimental-modules --experimental-import-meta-resolve --experimental-json-modules --experimental-loader=\"./node_modules/@nodeproto/configproto/src/node/loaders/flow.mjs\" --experimental-specifier-resolution=node --experimental-top-level-await --experimental-vm-modules --pending-deprecation --report-compact --report-dir=\"/var/.nodeproto/reports\" --report-filename=nodeprotolog --report-on-fatalerror --report-on-signal --report-signal=SIGUSR2 --report-uncaught-exception --trace-deprecation --trace-exit --trace-sigint --trace-uncaught --trace-warnings --unhandled-rejections=throw --use-largepages=on",
-    "NODE_OPTIONS_REMOVED": " --preserve-symlinks --preserve-symlinks-main   --v8-pool-size=0 --zero-fill-buffers",
+    "NODE_OPTIONS": "--diagnostic-dir=\"/var/.nodeproto/node/diagnostics\" --report-compact --report-dir=\"/var/.nodeproto/node/reports\" --report-filename=node-report --report-on-fatalerror --report-on-signal --report-signal=SIGUSR2 --report-uncaught-exception --pending-deprecation --trace-deprecation --trace-exit --trace-sigint --trace-warnings --unhandled-rejections=strict --enable-source-maps --experimental-abortcontroller --experimental-fetch --experimental-import-meta-resolve --experimental-json-modules --experimental-loader=\"./node_modules/@nodeproto/configproto/src/node/loaders/flow.mjs\" --experimental-modules --experimental-specifier-resolution=node --experimental-top-level-await --tls-max-v1.3 --tls-min-v1.3 --use-largepages=on",
     "PATH_DIST": "./dist",
     "PATH_SRC": "./src"
   },
@@ -61,7 +57,7 @@
     "uvu": "0.5.3"
   },
   "engines": {
-    "node": "^14.17.0 || ^16.11.0 || >=17.5.0"
+    "node": "16.14.0 || 17.5.0"
   },
   "exports": {
     ".": "./src/index.mjs",
@@ -78,6 +74,7 @@
     "@nodeproto",
     "api",
     "bodyguard",
+    "clickhouse",
     "cloudnative",
     "development",
     "docker",
@@ -101,6 +98,7 @@
     "prototype",
     "react",
     "secure",
+    "signoz",
     "ssl",
     "starter",
     "swagger",
@@ -114,26 +112,20 @@
     "linux"
   ],
   "scripts": {
+    "build": "NODE_ENV=production NODE_OPTIONS=\"$npm_package_config_NODE_OPTIONS\" pnpm repo:rm:dist && babel $npm_package_config_PATH_SRC -d $npm_package_config_PATH_DIST --copy-files --no-copy-ignored --ignore \"**/*.test.mjs\"",
     "jsync": "node --experimental-loader=\"./node_modules/@nodeproto/configproto/src/node/loaders/flow.mjs\" --experimental-specifier-resolution=node ./bin/jsync.js",
     "proto": "pnpm exec ultra -r",
     "proto:bin": "pnpm -r exec $*",
     "proto:script": "NODE_OPTIONS=\"$npm_package_config_NODE_OPTIONS\" pnpm -r $*",
     "proto:slice": "NODE_OPTIONS=\"$npm_package_config_NODE_OPTIONS\" pnpm exec ultra -r --filter",
     "repo:about": "npm run-script && npm --versions && pnpm -r config list --json t && echo \"NODE OPTIONS set to: $npm_package_config_NODE_OPTIONS\"",
-    "repo:about:scripts": "npm run-script",
-    "repo:check:configproto": "test -d node_modules/@nodepdroto/configproto",
-    "repo:check:jsync": "test -d node_modules/@nodeproto/jsync",
-    "repo:cp:browserslist": "rm -f .browserslistrc && cp ./node_modules/@nodeproto/configproto/.browserslistrc .",
-    "repo:cp:cjs": "rm -f ./dist/package.json && mkdir -p dist && cp ./node_modules/@nodeproto/configproto/src/node/cjs.json ./dist/package.json",
-    "repo:cp:configproto": "pnpm repo:cp:flow; pnpm repo:cp:cjs; pnpm repo:cp:browserslist; pnpm repo:cp:pretty",
-    "repo:cp:flow": "rm -f .flowconfig && cp ./node_modules/@nodeproto/configproto/.flowconfig .",
-    "repo:cp:pretty": "rm -f .prettier* && cp ./node_modules/@nodeproto/configproto/.prettier* .",
-    "repo:deps": "ultra --info",
     "repo:deps:direct": "npm ls",
+    "repo:deps:graph": "ultra --info",
     "repo:eslint": "eslint './**/*'",
     "repo:eslint:fix": "pnpm repo:eslint -- --fix",
     "repo:flow:coverage": "pnpm flow batch-coverage src",
     "repo:flowtyped:install": "flow-typed install",
+    "repo:jsync": "pnpm jsync",
     "repo:lint": "pnpm repo:eslint:fix; pnpm repo:flow:coverage",
     "repo:monitor": "ultra --monitor",
     "repo:nuke": "pnpm repo:rm:dist; pnpm repo:rm:nodemodules",
@@ -143,9 +135,8 @@
     "repo:scripts:v": "npm run-script",
     "repo:test": "NODE_OPTIONS=\"$npm_package_config_NODE_OPTIONS\" uvu ./src \"test.(m|c)?js\"",
     "repo:test:file": "NODE_OPTIONS=\"$npm_package_config_NODE_OPTIONS\" node $*",
-    "repo:test:help": "uvu --help",
-    "repo:testing": "pnpm repo:test; chokidar \"src/**/*(?:.test)?.(m|c)?js\" -c \"pnpm repo:test\"",
-    "repo:update": "pnpm -r up --latest"
+    "repo:testing": "pnpm repo:test; chokidar \"src/**/*(?:.test)?.(m|c)?js\" -c \"pnpm repo:test\" -t 4000 -d 4000",
+    "repo:update": "pnpm up --latest"
   },
   "ultra": {
     "concurrent": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -900,12 +900,10 @@ importers:
       express: 4.17.2
       flow-bin: 0.171.0
       flow-typed: 3.6.1
-      globby: 13.1.1
       husky: 7.0.4
       prettier: 2.5.1
       react: 18.0.0-rc.0
       react-dom: 18.0.0-rc.0
-      safe-compare: 1.1.4
       string-replace-loader: 3.1.0
       ultra-runner: 3.10.5
       uvu: 0.5.3
@@ -924,10 +922,8 @@ importers:
       download: 8.0.0
       env-cmd: 10.1.0
       express: 4.17.2
-      globby: 13.1.1
       react: 18.0.0-rc.0
       react-dom: 18.0.0-rc.0_react@18.0.0-rc.0
-      safe-compare: 1.1.4
       ultra-runner: 3.10.5
     devDependencies:
       '@babel/cli': 7.17.0_@babel+core@7.17.2
@@ -962,7 +958,7 @@ importers:
       prettier: 2.5.1
       string-replace-loader: 3.1.0_webpack@5.68.0
       uvu: 0.5.3
-      web-ext: 6.7.0_222e746a83bf798befe51ef9a9594616
+      web-ext: 6.7.0_a31594d3e0c89fa8f5b8edd9c2e3644a
       web-ext-translator: 4.0.0
       webextension-polyfill: 0.8.0
       webpack: 5.68.0
@@ -4932,14 +4928,14 @@ packages:
       strip-filename-increment: 2.0.1
     dev: false
 
-  /addons-linter/4.9.0_222e746a83bf798befe51ef9a9594616:
+  /addons-linter/4.9.0_a31594d3e0c89fa8f5b8edd9c2e3644a:
     resolution: {integrity: sha512-dknaL2zU9faJHpObJSFhh7RKM7S2uUImQL0I/tIny862wp8u6O7EhFu1ktdFRLO3NirHOTdn0366EcRrbAt1yg==}
     engines: {node: '>=12.21.0'}
     hasBin: true
     dependencies:
       '@mdn/browser-compat-data': 4.1.6
       addons-moz-compare: 1.2.0
-      addons-scanner-utils: 6.3.0_222e746a83bf798befe51ef9a9594616
+      addons-scanner-utils: 6.3.0_a31594d3e0c89fa8f5b8edd9c2e3644a
       ajv: 6.12.6
       ajv-merge-patch: 4.1.0_ajv@6.12.6
       chalk: 4.1.2
@@ -4981,7 +4977,7 @@ packages:
     resolution: {integrity: sha512-COG8qk2/dubPqabfcoJW4E7pm2EQDI43iMrHnhlobvq/uRMEzx/PYJ1KaUZ97Vgg44R3QdRG5CvDsTRbMUHcDw==}
     dev: true
 
-  /addons-scanner-utils/6.3.0_222e746a83bf798befe51ef9a9594616:
+  /addons-scanner-utils/6.3.0_a31594d3e0c89fa8f5b8edd9c2e3644a:
     resolution: {integrity: sha512-sD4U7TX/NFDUYVheydrcpHH9xG3E0eVBFDn1RuUkGpqRyay3SsOU75Pl2lWAbCmeE0Mh9inU1Fwl7Mm1VRWkZw==}
     peerDependencies:
       '@types/download': 8.0.1
@@ -4997,7 +4993,6 @@ packages:
       download: 8.0.0
       express: 4.17.2
       first-chunk-stream: 3.0.0
-      safe-compare: 1.1.4
       strip-bom-stream: 4.0.0
       upath: 2.0.1
       yauzl: 2.10.0
@@ -8309,17 +8304,6 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dependencies:
       array-union: 3.0.1
-      dir-glob: 3.0.1
-      fast-glob: 3.2.11
-      ignore: 5.2.0
-      merge2: 1.4.1
-      slash: 4.0.0
-    dev: false
-
-  /globby/13.1.1:
-    resolution: {integrity: sha512-XMzoDZbGZ37tufiv7g0N4F/zp3zkwdFtVbV3EHsVl1KQr4RPLfNoT068/97RPshz2J5xYNEjLKKBKaGHifBd3Q==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-    dependencies:
       dir-glob: 3.0.1
       fast-glob: 3.2.11
       ignore: 5.2.0
@@ -11862,12 +11846,6 @@ packages:
   /safe-buffer/5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
-  /safe-compare/1.1.4:
-    resolution: {integrity: sha512-b9wZ986HHCo/HbKrRpBJb2kqXMK9CEWIE1egeEvZsYn69ay3kdfl9nG3RyOcR+jInTDf7a86WQ1d4VJX7goSSQ==}
-    dependencies:
-      buffer-alloc: 1.2.0
-    dev: false
-
   /safe-json-stringify/1.2.0:
     resolution: {integrity: sha512-gH8eh2nZudPQO6TytOvbxnuhYBOvDBBLW52tz5q6X58lJcd/tkmqFR+5Z9adS8aJtURSXWThWy/xJtJwixErvg==}
     requiresBuild: true
@@ -13344,14 +13322,14 @@ packages:
       - supports-color
     dev: true
 
-  /web-ext/6.7.0_222e746a83bf798befe51ef9a9594616:
+  /web-ext/6.7.0_a31594d3e0c89fa8f5b8edd9c2e3644a:
     resolution: {integrity: sha512-QN+ufUPMNhLbrEqwFDOuoHy4m2OOPAp8NDMKJaWIByZRh8VPH+JoJ6/NAaIEcs9TPKnkA2018TNIJAfYN9EerA==}
     engines: {node: '>=12.0.0', npm: '>=6.9.0'}
     hasBin: true
     dependencies:
       '@babel/runtime': 7.13.9
       '@devicefarmer/adbkit': 2.11.3
-      addons-linter: 4.9.0_222e746a83bf798befe51ef9a9594616
+      addons-linter: 4.9.0_a31594d3e0c89fa8f5b8edd9c2e3644a
       bunyan: 1.8.15
       camelcase: 6.2.0
       chrome-launcher: 0.15.0


### PR DESCRIPTION
copy-webpack-plugin bug still exists after review of pnpm npmrc options (not ready to change anything there just yet)

this PR is to review the node options for 17.5 and see if the issue can be resolved there instead

I needed to review the node options anyway after moving to node 17.5